### PR TITLE
#191 manual bounding box - save info for next open

### DIFF
--- a/src/app/services/map.service.ts
+++ b/src/app/services/map.service.ts
@@ -114,14 +114,19 @@ export class MapService {
   m_oGeocoderControl = new Geocoder();
 
   /**
-   * Manual Boundig Box Event Listener
+   * Manual Bounding Box Event Listener
    */
   m_oManualBoundingBoxSubscription: BehaviorSubject<any> = new BehaviorSubject<any>(null);
 
   /**
-   * Manual Boundig Box Observable
+   * Manual Bounding Box Observable
    */
   _m_oManualBoundingBoxSubscription$ = this.m_oManualBoundingBoxSubscription.asObservable();
+
+  /**
+   * Manual Bounding Box Input
+   */
+  m_oManualBboxInput: any = null;
 
   /**
    * Init options for leaflet-draw
@@ -337,7 +342,6 @@ export class MapService {
     oMap.fitBounds(oBoundaries);
     oMap.setZoom(3);
 
-
     return oMap;
   }
 
@@ -376,7 +380,6 @@ export class MapService {
     * @references https://github.com/perliedman/leaflet-control-geocoder
     */
   initGeoSearchPluginForOpenStreetMap(oMap) {
-
     if (oMap == null) {
       oMap = this.m_oWasdiMap;
     }
@@ -394,11 +397,11 @@ export class MapService {
    * Clear Map 
    */
   clearMap() {
-
     if (this.m_oWasdiMap) {
       this.m_oDrawnItems.clearLayers();
       this.m_oWasdiMap.remove();
       this.m_oWasdiMap = null;
+      this.clearManualResult();
     }
   }
 
@@ -882,15 +885,17 @@ export class MapService {
         // And here we decide what to do with our button
         L.DomEvent.on(oButton, 'click', function () {
 
-          // We open the Manual Boundig Box Dialog
+          // We open the Manual Bounding Box Dialog
           let oDialog = oController.m_oDialog.open(ManualBoundingBoxComponent, {
+            data: { input: oController.m_oManualBboxInput },
             height: '500px',
             width: '600px'
           })
 
           // Once is closed...
           oDialog.afterClosed().subscribe(oResult => {
-
+            //Hold result if user re-opens box
+            oController.setManualResult(oResult)
             // We need a valid result
             if (FadeoutUtils.utilsIsObjectNullOrUndefined(oResult) === false) {
 
@@ -939,7 +944,7 @@ export class MapService {
     this.m_oDrawnItems.addLayer(oLayer);
     this.zoomOnBounds(aoBounds);
 
-    //Emit bounding box to listening componenet:
+    //Emit bounding box to listening component:
     this.m_oManualBoundingBoxSubscription.next(oLayer);
   }
 
@@ -997,4 +1002,15 @@ export class MapService {
     return this.m_oHttp.get(sUrl, { 'headers': aoHeaders });
   }
 
+  /**
+   * Set manual bounding box result to hold
+   */
+  setManualResult(oBboxResult: any): void {
+    this.m_oManualBboxInput = oBboxResult;
+  }
+
+  /**
+   * Clear manual bounding box result
+   */
+  clearManualResult(): void { }
 }

--- a/src/app/shared/shared-components/manual-bounding-box/manual-bounding-box.component.html
+++ b/src/app/shared/shared-components/manual-bounding-box/manual-bounding-box.component.html
@@ -27,8 +27,8 @@
             [m_sPlaceholder]="'ex. 49.4426671413'"></app-input-field>
     </div>
     <div [hidden]="!m_bShowJSON" class="flex-fill my-2 JSON-container">
-        <div #editor class="json-editor" style="height: 100%; width: 100%;" (keyup)="getJsonInput($event)"
-            (change)="getJsonInput($event)"></div>
+        <div #editor class="json-editor" style="height: 100%; width: 100%;" (keyup)="getJsonInput()"
+            (change)="getJsonInput()"></div>
         <app-button class="info-button" [m_sIconLeft]="'info'" [m_sSize]="'small'"
             (click)="openInfoDialog()"></app-button>
         <app-button class="json-button" [m_sLabel]="'DIALOG_PROCESSOR_UI_APP_FORMAT_JSON' | translate"

--- a/src/app/shared/shared-components/manual-bounding-box/manual-bounding-box.component.ts
+++ b/src/app/shared/shared-components/manual-bounding-box/manual-bounding-box.component.ts
@@ -1,5 +1,5 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
+import { Component, ElementRef, Input, OnInit, ViewChild, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { TranslateService } from '@ngx-translate/core';
 import FadeoutUtils from 'src/app/lib/utils/FadeoutJSUtils';
 import { ConstantsService } from 'src/app/services/constants.service';
@@ -36,6 +36,7 @@ export class ManualBoundingBoxComponent implements OnInit {
   public m_bShowJSON: boolean = false;
 
   constructor(
+    @Inject(MAT_DIALOG_DATA) private m_oData: any,
     private m_oConstantsService: ConstantsService,
     private m_oDialogRef: MatDialogRef<ManualBoundingBoxComponent>,
     private m_oJsonEditorService: JsonEditorService,
@@ -44,7 +45,10 @@ export class ManualBoundingBoxComponent implements OnInit {
 
 
   ngOnInit(): void {
-
+    if (FadeoutUtils.utilsIsObjectNullOrUndefined(this.m_oData.input) === false) { 
+      this.m_oBBox = this.m_oData.input;
+      this.getJsonInput()
+    }
   }
 
   saveBoundingBox() {
@@ -60,7 +64,7 @@ export class ManualBoundingBoxComponent implements OnInit {
     }
   }
 
-  getJsonInput(oEvent) {
+  getJsonInput() {
     this.m_sJSONParam = this.m_oJsonEditorService.getValue();
 
     try {


### PR DESCRIPTION
When the user inputs either JSON or the 4 inputs to the bounding box, the inputs are saved when closed. When the map is destroyed, the inputs are also destroyed